### PR TITLE
Match horizontal height to vertical width

### DIFF
--- a/stylesheets/atom.less
+++ b/stylesheets/atom.less
@@ -7,6 +7,7 @@
 
 ::-webkit-scrollbar {
     width: 7px;
+    height: 7px;
 }
 
 ::-webkit-scrollbar-track {
@@ -14,6 +15,6 @@
 }
 
 ::-webkit-scrollbar-thumb {
-	border-radius: 8px;
-	background: #ccc;
+  border-radius: 8px;
+  background: #ccc;
 }


### PR DESCRIPTION
Fixes dmackerman/atom-soda-light-ui#2

The height attribute for `-webkit-scrollbar` is used by the horizontal scrollbar and this matches the width of the vertical scrollbar to the height of the horizontal scrollbar.
