### PR TITLE
Make the highlight classes more readable

### DIFF
--- a/stylesheets/text.less
+++ b/stylesheets/text.less
@@ -67,7 +67,7 @@ code {
 
 .highlight-color(@name, @color) {
   .highlight-@{name} {
-    color: @text-color-highlight;
+    color: @text-color-selected;
     font-weight: bold;
     text-shadow: none;
     background-color: @color;


### PR DESCRIPTION
I was playing around with the [Styleguide](https://atom.io/packages/styleguide) today and I noticed that the colored highlight classes were not very readable. This is my attempt at fixing them.

Before:

![screen shot 2014-10-25 at 12 29 35 pm](https://cloud.githubusercontent.com/assets/1038121/4781221/e66723de-5c90-11e4-9d44-f1d6f05116c8.png)

After:

![screen shot 2014-10-25 at 2 44 45 pm](https://cloud.githubusercontent.com/assets/1038121/4781224/eba028c8-5c90-11e4-8d5a-7910647e0638.png)
